### PR TITLE
par(xpd=TRUE) was in the wrong place

### DIFF
--- a/R/legend.R
+++ b/R/legend.R
@@ -85,10 +85,10 @@ draw_legend <- function(gsplot) {
     
     for (legend.name in names(gsplot[['legend']])) {
       
-      par(xpd=TRUE)
-      
       legend <- gsplot[['legend']][[legend.name]]
       if (legend$draw) {
+        par(xpd=TRUE)
+        
         legend <- appendLegendColumnInfo(legend)
         legend <- appendLegendPositionConfiguration(legend)
         # set required legend argument to NA if not exists


### PR DESCRIPTION
`par(xpd=TRUE)` was being set in draw_legend, but it was outside of the logic that checked if the legend was going to be drawn or not. The par reset was inside that logic so if you did not call legend(), xpd was never reset. Obviously we still need to revisit the problems with changing par here, but this fixes the immediate bug
